### PR TITLE
Don't trigger observers when the object is not persisted

### DIFF
--- a/lib/wazowski/active_record_adapter.rb
+++ b/lib/wazowski/active_record_adapter.rb
@@ -68,9 +68,11 @@ module Wazowski
         end
 
         before_destroy do
-          self.class.__wazowski_all_nodes.each do |node_id|
-            __wazowski_presence_state.push([:delete, node_id])
-            TransactionState.current_state.register_model_changed(self)
+          unless self.new_record?
+            self.class.__wazowski_all_nodes.each do |node_id|
+              __wazowski_presence_state.push([:delete, node_id])
+              TransactionState.current_state.register_model_changed(self)
+            end
           end
         end
 

--- a/test/crud_actions_test.rb
+++ b/test/crud_actions_test.rb
@@ -60,6 +60,13 @@ class CrudActionsTest < BaseTest
     assert_equal [a, :delete, {}], StubReceiver.data[:trigger][1]
   end
 
+  test "DELETE / doesn't call the trigger on not persisted object" do
+    a = Post.new
+    a.destroy
+
+    assert_nil StubReceiver.data[:trigger]
+  end
+
   test "UPDATE / calls the trigger" do
     a = Comment.create! state: 'foo'
     a.update! state: 'bar'


### PR DESCRIPTION
Doing `MyModel.new.destroy!` should not trigger observers.